### PR TITLE
[feat] 화면공유 Websocket 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 
     //database
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
      //actuator

--- a/src/main/java/com/example/mogakserver/auth/api/controller/AuthController.java
+++ b/src/main/java/com/example/mogakserver/auth/api/controller/AuthController.java
@@ -2,8 +2,10 @@ package com.example.mogakserver.auth.api.controller;
 
 import com.example.mogakserver.auth.api.request.SignUpRequestDto;
 import com.example.mogakserver.auth.api.request.TokenRequestDto;
+import com.example.mogakserver.auth.application.response.LoginResponseDto;
+import com.example.mogakserver.auth.application.service.AuthService;
+import com.example.mogakserver.common.util.resolver.kakao.KakaoCode;
 import com.example.mogakserver.common.exception.dto.SuccessResponse;
-import com.example.mogakserver.common.config.resolver.kakao.KakaoCode;
 import com.example.mogakserver.common.exception.dto.TokenPair;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -11,8 +13,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import com.example.mogakserver.auth.application.response.LoginResponseDto;
-import com.example.mogakserver.auth.application.service.AuthService;
 
 import static com.example.mogakserver.common.exception.enums.SuccessCode.*;
 

--- a/src/main/java/com/example/mogakserver/common/config/redis/RedisConfig.java
+++ b/src/main/java/com/example/mogakserver/common/config/redis/RedisConfig.java
@@ -7,10 +7,13 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
+
     @Value("${spring.data.redis.host}")
     private String host;
 
@@ -31,4 +34,17 @@ public class RedisConfig {
         redisTemplate.setValueSerializer(new StringRedisSerializer());
         return redisTemplate;
     }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory connectionFactory) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        return container;
+    }
+
+    @Bean
+    public MessageListenerAdapter listenerAdapter(RedisMessageSubscriber subscriber) {
+        return new MessageListenerAdapter(subscriber);
+    }
+
 }

--- a/src/main/java/com/example/mogakserver/common/config/redis/RedisMessageSubscriber.java
+++ b/src/main/java/com/example/mogakserver/common/config/redis/RedisMessageSubscriber.java
@@ -1,0 +1,32 @@
+package com.example.mogakserver.common.config.redis;
+
+import com.example.mogakserver.external.socket.WebSocketBroadCaster;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisMessageSubscriber implements MessageListener {
+
+    private final WebSocketBroadCaster webSocketBroadcaster;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String channel = new String(pattern); // Redis 채널 이름
+        String body = new String(message.getBody()); // 메시지 내용
+
+        Long roomId = extractRoomIdFromChannel(channel);
+        webSocketBroadcaster.broadcast(roomId, body);
+    }
+
+    private Long extractRoomIdFromChannel(String channel) {
+        if (channel.startsWith("room-")) {
+            return Long.parseLong(channel.replace("room-", ""));
+        }
+        throw new IllegalArgumentException("Invalid channel name: " + channel);
+    }
+}
+
+

--- a/src/main/java/com/example/mogakserver/common/config/socket/WebSocketConfig.java
+++ b/src/main/java/com/example/mogakserver/common/config/socket/WebSocketConfig.java
@@ -1,0 +1,20 @@
+package com.example.mogakserver.common.config.socket;
+
+import com.example.mogakserver.external.socket.WebRtcWebSocketHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketConfigurer {
+    private final WebRtcWebSocketHandler webRtcWebSocketHandler;
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(webRtcWebSocketHandler, "/ws/webrtc")
+                .setAllowedOrigins("*");
+    }
+}

--- a/src/main/java/com/example/mogakserver/common/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/example/mogakserver/common/config/swagger/SwaggerConfig.java
@@ -1,7 +1,6 @@
 package com.example.mogakserver.common.config.swagger;
 
-import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
-import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
@@ -10,23 +9,20 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@SecurityScheme(
-        name = "JWT Auth",
-        type = SecuritySchemeType.HTTP,
-        bearerFormat = "JWT",
-        scheme = "bearer"
-)
 public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
-        Info info = new Info()
-                .title("Mogak Swagger")
-                .description("Mogak API Docs")
-                .version("1.0.0");
 
         return new OpenAPI()
+                .info(new Info()
+                        .title("Mogak Swagger")
+                        .description("Mogak API Docs")
+                        .version("1.0.0"))
                 .addServersItem(new Server().url("/"))
-                .components(new Components())
-                .info(info);
+                .components(new Components()
+                        .addSecuritySchemes("JWT Auth", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
     }
 }

--- a/src/main/java/com/example/mogakserver/common/config/swagger/WebConfig.java
+++ b/src/main/java/com/example/mogakserver/common/config/swagger/WebConfig.java
@@ -1,7 +1,7 @@
 package com.example.mogakserver.common.config.swagger;
 
-import com.example.mogakserver.common.config.resolver.kakao.KakaoCodeResolver;
-import com.example.mogakserver.common.config.resolver.user.UserResolver;
+import com.example.mogakserver.common.util.resolver.kakao.KakaoCodeResolver;
+import com.example.mogakserver.common.util.resolver.user.UserResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;

--- a/src/main/java/com/example/mogakserver/common/exception/enums/SuccessCode.java
+++ b/src/main/java/com/example/mogakserver/common/exception/enums/SuccessCode.java
@@ -11,7 +11,8 @@ public enum SuccessCode {
     SIGNUP_SUCCESS(HttpStatus.OK, "신규 회원 입니다."),
     SOCIAL_LOGIN_SUCCESS(HttpStatus.OK, "카카오 로그인 성공입니다."),
     LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃 성공입니다."),
-    REFRESH_SUCCESS(HttpStatus.OK, "토큰 갱신 성공입니다.");
+    REFRESH_SUCCESS(HttpStatus.OK, "토큰 갱신 성공입니다."),
+    GET_SCREEN_SHARE_USERS_SUCCESS(HttpStatus.OK, "화면공유 사용자 리스트 반환 성공입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/mogakserver/common/util/resolver/kakao/KakaoCode.java
+++ b/src/main/java/com/example/mogakserver/common/util/resolver/kakao/KakaoCode.java
@@ -1,4 +1,4 @@
-package com.example.mogakserver.common.config.resolver.kakao;
+package com.example.mogakserver.common.util.resolver.kakao;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/com/example/mogakserver/common/util/resolver/kakao/KakaoCodeResolver.java
+++ b/src/main/java/com/example/mogakserver/common/util/resolver/kakao/KakaoCodeResolver.java
@@ -1,4 +1,4 @@
-package com.example.mogakserver.common.config.resolver.kakao;
+package com.example.mogakserver.common.util.resolver.kakao;
 
 import com.example.mogakserver.common.exception.model.BadRequestException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/example/mogakserver/common/util/resolver/user/UserId.java
+++ b/src/main/java/com/example/mogakserver/common/util/resolver/user/UserId.java
@@ -1,4 +1,4 @@
-package com.example.mogakserver.common.config.resolver.user;
+package com.example.mogakserver.common.util.resolver.user;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/com/example/mogakserver/common/util/resolver/user/UserResolver.java
+++ b/src/main/java/com/example/mogakserver/common/util/resolver/user/UserResolver.java
@@ -1,4 +1,4 @@
-package com.example.mogakserver.common.config.resolver.user;
+package com.example.mogakserver.common.util.resolver.user;
 
 import com.example.mogakserver.common.exception.model.BadRequestException;
 import com.example.mogakserver.common.exception.model.UnAuthorizedException;

--- a/src/main/java/com/example/mogakserver/external/socket/WebRtcWebSocketHandler.java
+++ b/src/main/java/com/example/mogakserver/external/socket/WebRtcWebSocketHandler.java
@@ -1,0 +1,188 @@
+package com.example.mogakserver.external.socket;
+
+import com.example.mogakserver.common.config.jwt.JwtService;
+import com.example.mogakserver.external.socket.dto.MessageDTO;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@RequiredArgsConstructor
+public class WebRtcWebSocketHandler extends TextWebSocketHandler {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final JwtService jwtService;
+    private final MessageListenerAdapter listenerAdapter;
+    private final WebSocketBroadCaster webSocketBroadcaster;
+
+    private static final String CHANNEL_PREFIX = "room-";
+    private static final String SCREEN_SHARE_KEY_PREFIX = "screen-share-room-";
+    private static final Map<Long, WebSocketSession> sessionMap = new ConcurrentHashMap<>();
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        Long roomId = getRoomId(session);
+        Long userId = getUserIdFromHeader(session);
+
+        // 중복 연결 체크
+        if (sessionMap.containsKey(userId)) {
+            WebSocketSession existingSession = sessionMap.get(userId);
+            existingSession.close();
+            sessionMap.remove(userId);
+        }
+
+        sessionMap.put(userId, session);
+        webSocketBroadcaster.addSession(roomId, session);
+
+        // Redis 구독 동적으로 추가
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.addMessageListener(listenerAdapter, new PatternTopic(getChannelName(roomId)));
+
+        // 화면 공유 중인 사용자 목록
+        Set<String> screenShareUsers = getScreenShareUsers(roomId);
+
+        if (!screenShareUsers.isEmpty()) {
+            String screenShareMessage = String.format(
+                    "{\"type\":\"screen-share-users\", \"users\":%s}",
+                    new ObjectMapper().writeValueAsString(screenShareUsers)
+            );
+            session.sendMessage(new TextMessage(screenShareMessage));
+        }
+
+        redisTemplate.convertAndSend(getChannelName(roomId), serializeMessage(createEventMessage("participant-joined", userId)));
+    }
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        String payload = message.getPayload();
+        MessageDTO messageDto = parseMessage(payload);
+        if (messageDto == null) {
+            session.sendMessage(new TextMessage("{\"type\":\"error\", \"message\":\"Invalid JSON format\"}"));
+            return;
+        }
+
+        String messageType = messageDto.type();
+        Long roomId = getRoomId(session);
+        Long userId = getUserIdFromHeader(session);
+
+        String eventMessage = serializeMessage(createEventMessage(messageType, userId));
+
+        switch (messageType) {
+            case "screen-share-start":
+                publishToRedis(roomId, eventMessage);
+                addScreenShareUser(roomId, userId);
+                webSocketBroadcaster.broadcast(roomId, eventMessage);
+                break;
+
+            case "screen-share-stop":
+                publishToRedis(roomId, eventMessage);
+                removeScreenShareUser(roomId, userId);
+                webSocketBroadcaster.broadcast(roomId, eventMessage);
+                break;
+
+            default:
+                session.sendMessage(new TextMessage("{\"type\":\"error\", \"message\":\"Unknown message type\"}"));
+        }
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        Long roomId = getRoomId(session);
+        Long userId = getUserIdFromHeader(session);
+
+        webSocketBroadcaster.removeSession(roomId, session);
+        sessionMap.remove(userId);
+
+        redisTemplate.convertAndSend(getChannelName(roomId), serializeMessage(createEventMessage("participant-left", userId)));
+    }
+
+    // 화면 공유 상태 추가
+    private void addScreenShareUser(Long roomId, Long userId) {
+        String key = SCREEN_SHARE_KEY_PREFIX + roomId;
+        redisTemplate.opsForSet().add(key, String.valueOf(userId));
+    }
+
+    // 화면 공유 상태 제거
+    private void removeScreenShareUser(Long roomId, Long userId) {
+        String key = SCREEN_SHARE_KEY_PREFIX + roomId;
+        redisTemplate.opsForSet().remove(key, String.valueOf(userId));
+    }
+
+    private Long getRoomId(WebSocketSession session) {
+        String query = session.getUri().getQuery();
+        try {
+            String roomIdStr = query.split("roomId=")[1].split("&")[0];
+            return Long.parseLong(roomIdStr);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid roomId in URL query: " + query);
+        }
+    }
+
+    private Long getUserIdFromHeader(WebSocketSession session) {
+        String token = session.getHandshakeHeaders().getFirst("Authorization");
+        if (token == null || !token.startsWith("Bearer ")) {
+            throw new IllegalArgumentException("Authorization header missing or invalid");
+        }
+
+        String encodedUserId = token.substring("Bearer ".length());
+        if (!jwtService.verifyToken(encodedUserId)) {
+            throw new IllegalArgumentException("Invalid token");
+        }
+
+        String decodedUserId = jwtService.getUserIdInToken(encodedUserId);
+        try {
+            return Long.parseLong(decodedUserId);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid userId in token");
+        }
+    }
+
+    private void publishToRedis(Long roomId, String message) {
+        redisTemplate.convertAndSend(getChannelName(roomId), message);
+    }
+
+    private String getChannelName(Long roomId) {
+        return CHANNEL_PREFIX + roomId;
+    }
+    private Set<String> getScreenShareUsers(Long roomId) {
+        String key = SCREEN_SHARE_KEY_PREFIX + roomId;
+        return redisTemplate.opsForSet().members(key);
+    }
+
+    private MessageDTO parseMessage(String json) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(json, MessageDTO.class);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+    private String serializeMessage(MessageDTO message) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.writeValueAsString(message);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize message", e);
+        }
+    }
+
+    private MessageDTO createEventMessage(String type, Long userId) {
+        return new MessageDTO(type, userId);
+    }
+}
+
+

--- a/src/main/java/com/example/mogakserver/external/socket/WebSocketBroadCaster.java
+++ b/src/main/java/com/example/mogakserver/external/socket/WebSocketBroadCaster.java
@@ -1,0 +1,45 @@
+package com.example.mogakserver.external.socket;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Component
+public class WebSocketBroadCaster {
+
+    private final Map<Long, List<WebSocketSession>> roomSessions = new ConcurrentHashMap<>();
+
+    public void addSession(Long roomId, WebSocketSession session) {
+        roomSessions.computeIfAbsent(roomId, k -> new CopyOnWriteArrayList<>()).add(session);
+    }
+
+    public void removeSession(Long roomId, WebSocketSession session) {
+        List<WebSocketSession> sessions = roomSessions.get(roomId);
+        if (sessions != null) {
+            sessions.remove(session);
+            if (sessions.isEmpty()) {
+                roomSessions.remove(roomId);
+            }
+        }
+    }
+
+    public void broadcast(Long roomId, String message) {
+        List<WebSocketSession> sessions = roomSessions.getOrDefault(roomId, List.of());
+        for (WebSocketSession session : sessions) {
+            try {
+                if (session.isOpen()) {
+                    session.sendMessage(new TextMessage(message));
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}
+

--- a/src/main/java/com/example/mogakserver/external/socket/dto/MessageDTO.java
+++ b/src/main/java/com/example/mogakserver/external/socket/dto/MessageDTO.java
@@ -1,0 +1,7 @@
+package com.example.mogakserver.external.socket.dto;
+
+public record MessageDTO(
+        String type,
+        Long userId
+) {
+}

--- a/src/main/java/com/example/mogakserver/room/api/controller/RoomController.java
+++ b/src/main/java/com/example/mogakserver/room/api/controller/RoomController.java
@@ -1,0 +1,42 @@
+package com.example.mogakserver.room.api.controller;
+
+import com.example.mogakserver.common.exception.dto.ErrorResponse;
+import com.example.mogakserver.common.exception.dto.SuccessResponse;
+import com.example.mogakserver.common.exception.enums.SuccessCode;
+import com.example.mogakserver.common.util.resolver.user.UserId;
+import com.example.mogakserver.room.application.response.ScreenShareUsersListDTO;
+import com.example.mogakserver.room.application.service.RoomService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/room")
+@RequiredArgsConstructor
+public class RoomController {
+
+    private final RoomService roomService;
+
+    @Operation(summary = "[JWT] 화면공유 사용자 리스트 조회", description = "해당 방에서 화면공유 중인 userId 리스트 조회 api 입니다")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "화면공유 사용자 조회 성공", content = @Content(schema = @Schema(implementation = ScreenShareUsersListDTO.class))),
+            @ApiResponse(responseCode = "404", description = "유저가 존재하지 않습니다", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류 입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @SecurityRequirement(name = "JWT Auth")
+    @GetMapping("/{roomId}/screenshare/users")
+    public SuccessResponse<ScreenShareUsersListDTO> getScreenShareUsers(
+            @Parameter(hidden = true) @UserId Long userId,
+            @Parameter(name = "roomId", description = "방 id") @PathVariable(value = "roomId") Long roomId,
+            @Parameter(name = "page", description = "페이지 ") @RequestParam(value = "page") int page,
+            @Parameter(name = "size", description = "페이지 ") @RequestParam(value = "size") int size
+    ) {
+        return SuccessResponse.success(SuccessCode.GET_SCREEN_SHARE_USERS_SUCCESS, roomService.getScreenShareUsers(roomId, page, size));
+    }
+}

--- a/src/main/java/com/example/mogakserver/room/application/response/ScreenShareUsersListDTO.java
+++ b/src/main/java/com/example/mogakserver/room/application/response/ScreenShareUsersListDTO.java
@@ -1,0 +1,14 @@
+package com.example.mogakserver.room.application.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ScreenShareUsersListDTO(
+        List<Long> users,
+        int currentPage,
+        int totalPages
+) {
+
+}

--- a/src/main/java/com/example/mogakserver/room/application/service/RoomService.java
+++ b/src/main/java/com/example/mogakserver/room/application/service/RoomService.java
@@ -1,0 +1,61 @@
+package com.example.mogakserver.room.application.service;
+
+import com.example.mogakserver.room.application.response.ScreenShareUsersListDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class RoomService {
+    private static final String SCREEN_SHARE_KEY_PREFIX = "screen-share-room-";
+    private final RedisTemplate<String, String> redisTemplate;
+    public ScreenShareUsersListDTO getScreenShareUsers(Long roomId, int page, int size) {
+        String key = SCREEN_SHARE_KEY_PREFIX + roomId;
+        Set<String> userIds = redisTemplate.opsForSet().members(key);
+
+        if (userIds == null || userIds.isEmpty()) {
+            return createEmptyScreenShareUsersDTO(page, 0);
+        }
+
+        List<Long> sortedUsers = userIds.stream()
+                .map(Long::valueOf)
+                .sorted()
+                .collect(Collectors.toList());
+
+        return createPagedScreenShareUsersDTO(sortedUsers, page, size);
+    }
+
+    private ScreenShareUsersListDTO createEmptyScreenShareUsersDTO(int currentPage, int totalPages) {
+        return ScreenShareUsersListDTO.builder()
+                .users(Collections.emptyList())
+                .currentPage(currentPage)
+                .totalPages(totalPages)
+                .build();
+    }
+
+    private ScreenShareUsersListDTO createPagedScreenShareUsersDTO(List<Long> users, int page, int size) {
+        int totalUsers = users.size();
+        int totalPages = (int) Math.ceil((double) totalUsers / size);
+
+        // 페이지 범위를 초과한 경우 빈 결과
+        if (page >= totalPages) {
+            return createEmptyScreenShareUsersDTO(page, totalPages);
+        }
+
+        int fromIndex = page * size;
+        int toIndex = Math.min(fromIndex + size, totalUsers);
+        List<Long> pagedUsers = users.subList(fromIndex, toIndex);
+
+        return ScreenShareUsersListDTO.builder()
+                .users(pagedUsers)
+                .currentPage(page)
+                .totalPages(totalPages)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🍀 연관된 이슈
- resolved #3 

## 💻 작업 내용
- websocket 이 연결이 되면 화면공유 중인 사용자들 리스트 ( redis 에 hash 형태로 저장됨) 를 반환해서 놓친 연결이 있는지 확인합니다.
이는 redis pub/sub 방식의 단점( 네트워크 연결 중단 등 문제 발생 시 데이터 유실) 을 보완하기 위해 사용했습니다.

- 특정 사용자가 화면공유를 시작/종료할 경우, redis pub/sub 방식을 활용해서 room-{roomId} 를 구독한 사용자들 (저 방에 있는 사람들) 모두에게 알리는 방식으로 구현하였습니다. 

- 화면공유 시작/종료 시 redis 에 hash (key-value) 형태로 저장하여 화면공유 사용자 리스트 페이징 조회 api 를 구현할 수 있도록 하였습니다. 


## 👥 리뷰 요청 및 전달 사항
리뷰어가 검토할 때 중점을 두어야 할 부분, 질문, 공유 사항을 작성해주세요

- [x]  `main` 브랜치의 최신 코드를 `pull` 받았나요?
