### PR TITLE
[feat] 유저 로직 수정

### DIFF
--- a/src/main/java/com/example/mogakserver/auth/api/controller/AuthController.java
+++ b/src/main/java/com/example/mogakserver/auth/api/controller/AuthController.java
@@ -41,7 +41,7 @@ public class AuthController {
     }
 
 
-    @Operation(summary = "[JWT] 회원가입 API", description = "카카오 로그인 사용자 회원가입")
+    @Operation(summary = "회원가입 API", description = "카카오 로그인 사용자 회원가입")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "회원가입 성공",
                     content = @Content(schema = @Schema(implementation = LoginResponseDto.class))),
@@ -51,11 +51,9 @@ public class AuthController {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PostMapping("/signup")
-    @SecurityRequirement(name = "JWT Auth")
     public SuccessResponse<LoginResponseDto> signUp(
-            @RequestBody SignUpRequestDTO signUpRequest,
-            @Parameter(hidden = true) @UserId Long userId) {
-        return SuccessResponse.success(SOCIAL_LOGIN_SUCCESS, authService.signUp(userId, signUpRequest));
+            @RequestBody SignUpRequestDTO signUpRequest) {
+        return SuccessResponse.success(SOCIAL_LOGIN_SUCCESS, authService.signUp(signUpRequest));
     }
 
 

--- a/src/main/java/com/example/mogakserver/auth/api/request/SignUpRequestDTO.java
+++ b/src/main/java/com/example/mogakserver/auth/api/request/SignUpRequestDTO.java
@@ -3,6 +3,7 @@ package com.example.mogakserver.auth.api.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record SignUpRequestDTO(
+        @NotBlank String kakaoCode,
         @NotBlank String nickName,
         String portfolioUrl
 ) {

--- a/src/main/java/com/example/mogakserver/auth/application/response/LoginResponseDto.java
+++ b/src/main/java/com/example/mogakserver/auth/application/response/LoginResponseDto.java
@@ -9,24 +9,21 @@ public record LoginResponseDto(
         Long userId,
 
         String accessToken,
-        String refreshToken,
-
-        @JsonProperty("isNewUser")
-        boolean isNewUser
+        String refreshToken
 ) {
 
     // 신규 사용자 로그인
     public static LoginResponseDto NewUserResponse(Long userId, String accessToken, String refreshToken) {
-        return new LoginResponseDto(userId, accessToken, refreshToken, true);
+        return new LoginResponseDto(userId, accessToken, refreshToken);
     }
 
     // 기존 사용자 로그인
     public static LoginResponseDto ExistingUserResponse(Long userId, String accessToken, String refreshToken) {
-        return new LoginResponseDto(userId, accessToken, refreshToken, false);
+        return new LoginResponseDto(userId, accessToken, refreshToken);
     }
 
     // 회원가입
     public static LoginResponseDto SignupResponse(Long userId, String accessToken, String refreshToken) {
-        return new LoginResponseDto(userId, accessToken, refreshToken, false);
+        return new LoginResponseDto(userId, accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/example/mogakserver/common/exception/enums/ErrorCode.java
+++ b/src/main/java/com/example/mogakserver/common/exception/enums/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
 
     //404
     USER_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 유저는 존재하지 않습니다."),
+    KAKAO_ID_RETRIEVAL_FAILED_EXCEPTION(HttpStatus.NOT_FOUND, "카카오 ID 조회에 실패했습니다."),
     ROOM_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 방은 존재하지 않습니다."),
     NOT_FOUND_RESOURCE_EXCEPTION(HttpStatus.NOT_FOUND, "해당 자원을 찾을 수 없습니다."),
     NOT_FOUND_VERIFICATION_CODE_EXCEPTION(HttpStatus.NOT_FOUND, "인증 코드가 존재하지 않습니다."),
@@ -36,12 +37,14 @@ public enum ErrorCode {
     METHOD_NOT_ALLOWED_EXCEPTION(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 메소드 입니다."),
 
     // 409 Conflict
+    ALREADY_EXIST_USER_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 유저입니다"),
     ALREADY_EXIST_OFFER_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 제안서입니다"),
     ALREADY_EXIST_NICKNAME_EXCEPTION(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
     ALREADY_EXIST_ROOM_EXCEPTION(HttpStatus.CONFLICT, "이미 사용 중인 방 이름입니다."),
 
     // 500
-    INTERNAL_SERVER_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+    INTERNAL_SERVER_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+    KAKAO_SERVER_ERROR_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 서버와의 통신 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/mogakserver/common/exception/enums/SuccessCode.java
+++ b/src/main/java/com/example/mogakserver/common/exception/enums/SuccessCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum SuccessCode {
 
+    KAKAO_CODE_SUCCESS(HttpStatus.OK, "인가 코드 발급 성공"),
     SIGNUP_SUCCESS(HttpStatus.OK, "신규 회원 입니다."),
     SOCIAL_LOGIN_SUCCESS(HttpStatus.OK, "카카오 로그인 성공입니다."),
     LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃 성공입니다."),

--- a/src/main/java/com/example/mogakserver/external/kakao/service/KakaoSocialService.java
+++ b/src/main/java/com/example/mogakserver/external/kakao/service/KakaoSocialService.java
@@ -1,5 +1,9 @@
 package com.example.mogakserver.external.kakao.service;
 
+import com.example.mogakserver.common.exception.dto.SuccessResponse;
+import com.example.mogakserver.common.exception.enums.ErrorCode;
+import com.example.mogakserver.common.exception.enums.SuccessCode;
+import com.example.mogakserver.common.exception.model.NotFoundException;
 import com.example.mogakserver.external.kakao.dto.response.KakaoAccessTokenResponse;
 import com.example.mogakserver.external.kakao.dto.response.KakaoUserResponse;
 import com.example.mogakserver.external.kakao.feign.KakaoApiClient;
@@ -7,6 +11,7 @@ import com.example.mogakserver.external.kakao.feign.KakaoAuthApiClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 
 @Service
 @RequiredArgsConstructor
@@ -24,15 +29,29 @@ public class KakaoSocialService extends SocialService {
     private final KakaoApiClient kakaoApiClient;
 
     @Override
-    public Long getIdFromKakao(String kakaoCode) {
-        KakaoAccessTokenResponse tokenResponse = kakaoAuthApiClient.getOAuth2AccessToken(
-                GRANT_TYPE,
-                clientId,
-                redirectUri,
-                kakaoCode
-        );
+    public SuccessResponse<Long> getIdFromKakao(String kakaoCode) {
+        try {
+            KakaoAccessTokenResponse tokenResponse = kakaoAuthApiClient.getOAuth2AccessToken(
+                    GRANT_TYPE,
+                    clientId,
+                    redirectUri,
+                    kakaoCode
+            );
 
-        KakaoUserResponse userResponse = kakaoApiClient.getUserInformation(Bearer + tokenResponse.accessToken());
-        return userResponse.id();
+            if (tokenResponse.accessToken() == null || tokenResponse.accessToken().isEmpty()) {
+                throw new NotFoundException(ErrorCode.INVALID_KAKAO_CODE_EXCEPTION);
+            }
+
+            KakaoUserResponse userResponse = kakaoApiClient.getUserInformation(Bearer + tokenResponse.accessToken());
+            return SuccessResponse.success(SuccessCode.KAKAO_CODE_SUCCESS, userResponse.id());
+
+        } catch (HttpClientErrorException e) {
+            if (e.getStatusCode().is4xxClientError()) {
+                throw new NotFoundException(ErrorCode.INVALID_KAKAO_CODE_EXCEPTION);
+            }
+            throw new NotFoundException(ErrorCode.KAKAO_SERVER_ERROR_EXCEPTION);
+        } catch (Exception e) {
+            throw new NotFoundException(ErrorCode.KAKAO_SERVER_ERROR_EXCEPTION);
+        }
     }
 }

--- a/src/main/java/com/example/mogakserver/external/kakao/service/SocialService.java
+++ b/src/main/java/com/example/mogakserver/external/kakao/service/SocialService.java
@@ -1,6 +1,8 @@
 package com.example.mogakserver.external.kakao.service;
 
+import com.example.mogakserver.common.exception.dto.SuccessResponse;
+
 public abstract class SocialService {
-    public abstract Long getIdFromKakao(String kakaoCode);
+    public abstract SuccessResponse<Long> getIdFromKakao(String kakaoCode);
 
 }

--- a/src/main/java/com/example/mogakserver/user/domain/entity/User.java
+++ b/src/main/java/com/example/mogakserver/user/domain/entity/User.java
@@ -32,9 +32,9 @@ public class User {
 
     private String email;
 
-    private Long todayAddedTime = 0L;
-
     private Boolean isNewUser = true;
+
+    private Long todayAddedTime = 0L;
 
     @Version
     private Integer version = 0;
@@ -62,10 +62,6 @@ public class User {
 
     public void resetTodayAddedTime() {
         this.todayAddedTime = 0L;
-    }
-
-    public void completeSignUp() {
-        this.isNewUser = false;
     }
 
     public void setVersion(int version){


### PR DESCRIPTION
## 🍀 연관된 이슈
- resolved #26 

## 💻 작업 내용
카카오 로그인 했을 때 신규회원일 경우 404 에러 처리 뜨게 해두었습니다
404가 뜨면 프론트에서 회원가입 페이지로 이동하고 회원가입 api 요청 보낼 때 인가 코드를 함께 보내서 그때 테이블에 새로운 유저가 생기도록 수정하였습니다!

앤드 최대한 꼼꼼히 예외처리 해보려고 노력해보앗슴다... 허허

## 👥 리뷰 요청 및 전달 사항

- [x]  `main` 브랜치의 최신 코드를 `pull` 받았나요?
