### PR TITLE
[fix] 유저 로직 수정

### DIFF
--- a/src/main/java/com/example/mogakserver/auth/api/controller/AuthController.java
+++ b/src/main/java/com/example/mogakserver/auth/api/controller/AuthController.java
@@ -37,7 +37,13 @@ public class AuthController {
     })
     @PostMapping("/login")
     public SuccessResponse<LoginResponseDto> login(@RequestBody LoginRequestDTO loginRequest) {
-        return SuccessResponse.success(SOCIAL_LOGIN_SUCCESS, authService.login(loginRequest.kakaoCode()));
+        LoginResponseDto loginResponse = authService.login(loginRequest.kakaoCode());
+
+        if ("fail".equals(loginResponse.status())) {
+            return SuccessResponse.success(SIGNUP_REQUIRED, loginResponse);
+        }
+
+        return SuccessResponse.success(SOCIAL_LOGIN_SUCCESS, loginResponse);
     }
 
 

--- a/src/main/java/com/example/mogakserver/auth/api/request/SignUpRequestDTO.java
+++ b/src/main/java/com/example/mogakserver/auth/api/request/SignUpRequestDTO.java
@@ -3,7 +3,7 @@ package com.example.mogakserver.auth.api.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record SignUpRequestDTO(
-        @NotBlank String kakaoCode,
+        @NotBlank Long kakaoId,
         @NotBlank String nickName,
         String portfolioUrl
 ) {

--- a/src/main/java/com/example/mogakserver/auth/application/response/LoginResponseDto.java
+++ b/src/main/java/com/example/mogakserver/auth/application/response/LoginResponseDto.java
@@ -5,25 +5,28 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record LoginResponseDto(
-        @JsonProperty("userId")
-        Long userId,
+        @JsonProperty("kakaoId")
+        Long kakaoId,
+
+        @JsonProperty("status")
+        String status,
 
         String accessToken,
         String refreshToken
 ) {
 
     // 신규 사용자 로그인
-    public static LoginResponseDto NewUserResponse(Long userId, String accessToken, String refreshToken) {
-        return new LoginResponseDto(userId, accessToken, refreshToken);
+    public static LoginResponseDto NewUserResponse(Long kakaoId) {
+        return new LoginResponseDto(kakaoId, "fail", null, null);
     }
 
     // 기존 사용자 로그인
-    public static LoginResponseDto ExistingUserResponse(Long userId, String accessToken, String refreshToken) {
-        return new LoginResponseDto(userId, accessToken, refreshToken);
+    public static LoginResponseDto ExistingUserResponse(String accessToken, String refreshToken) {
+        return new LoginResponseDto(null, "success", accessToken, refreshToken);
     }
 
     // 회원가입
-    public static LoginResponseDto SignupResponse(Long userId, String accessToken, String refreshToken) {
-        return new LoginResponseDto(userId, accessToken, refreshToken);
+    public static LoginResponseDto SignupResponse(String accessToken, String refreshToken) {
+        return new LoginResponseDto(null, null, accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/example/mogakserver/common/exception/enums/ErrorCode.java
+++ b/src/main/java/com/example/mogakserver/common/exception/enums/ErrorCode.java
@@ -9,7 +9,6 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // 400
     INVALID_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰을 입력했습니다."),
-    EMPTY_KAKAO_CODE_EXCEPTION(HttpStatus.BAD_REQUEST, "카카오 코드 값을 입력해 주세요."),
     INVALID_KAKAO_CODE_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 카카오 코드를 입력했습니다."),
     EXPIRE_VERIFICATION_CODE_EXCEPTION(HttpStatus.BAD_REQUEST, "만료된 인증 코드입니다."),
     INVALID_VALUE_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 타입 값을 입력했습니다."),
@@ -18,8 +17,10 @@ public enum ErrorCode {
     INVALID_EMPTY_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 값은 null 또 상수 값이 유효하지 않습니다."),
 
     // 401
+    EMPTY_KAKAO_CODE_EXCEPTION(HttpStatus.UNAUTHORIZED, "카카오 인증을 위해 유효한 코드를 제공해 주세요."),
+    EMPTY_KAKAO_ID_EXCEPTION(HttpStatus.UNAUTHORIZED, "카카오 ID 값을 입력해 주세요."),
     TOKEN_NOT_CONTAINED_EXCEPTION(HttpStatus.UNAUTHORIZED, "Access Token이 필요합니다."),
-    TOKEN_TIME_EXPIRED_EXCEPTION(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다. 다시 로그인 해주세요."),
+    TOKEN_TIME_EXPIRED_EXCEPTION(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
 
     //403
     ROOM_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "방 관련 권한이 없습니다."),
@@ -37,8 +38,8 @@ public enum ErrorCode {
     METHOD_NOT_ALLOWED_EXCEPTION(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 메소드 입니다."),
 
     // 409 Conflict
-    ALREADY_EXIST_USER_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 유저입니다"),
-    ALREADY_EXIST_OFFER_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 제안서입니다"),
+    ALREADY_EXIST_USER_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 유저입니다."),
+    ALREADY_EXIST_OFFER_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 제안서입니다."),
     ALREADY_EXIST_NICKNAME_EXCEPTION(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
     ALREADY_EXIST_ROOM_EXCEPTION(HttpStatus.CONFLICT, "이미 사용 중인 방 이름입니다."),
 

--- a/src/main/java/com/example/mogakserver/common/exception/enums/SuccessCode.java
+++ b/src/main/java/com/example/mogakserver/common/exception/enums/SuccessCode.java
@@ -9,8 +9,9 @@ import org.springframework.http.HttpStatus;
 public enum SuccessCode {
 
     KAKAO_CODE_SUCCESS(HttpStatus.OK, "인가 코드 발급 성공"),
-    SIGNUP_SUCCESS(HttpStatus.OK, "신규 회원 입니다."),
     SOCIAL_LOGIN_SUCCESS(HttpStatus.OK, "카카오 로그인 성공입니다."),
+    SIGNUP_REQUIRED(HttpStatus.OK, "회원가입이 필요한 사용자입니다."),
+    SIGNUP_SUCCESS(HttpStatus.OK, "회원가입이 완료되었습니다."),
     LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃 성공입니다."),
     REFRESH_SUCCESS(HttpStatus.OK, "토큰 갱신 성공입니다."),
     GET_AVAILABLE_NICKNAME(HttpStatus.OK, "사용 가능한 닉네임입니다."),


### PR DESCRIPTION
## 🍀 연관된 이슈
- resolved #30

## 💻 작업 내용
회원가입 api 요청시 kakaoCode -> kakaoId 로 변경

로그인 api 응답값에서 
- 신규 회원일 경우 kakaoId, status: faill 반환
- 기존 회원일 경우 accessToken, refreshToken, status: success 반환

## 👥 리뷰 요청 및 전달 사항
기존 코드대로 진행하면 사용자가 인가 코드를 두번 받아야 하는(카카오 로그인 버튼을 두번 누르는) 상황이 발생해서 신규회원이 로그인 api 요청 시, kakaoId를 반환해주고 이 아이디값을 가지고 프론트에서 회원가입 진행하도록 로직 수정했습니다!

- [x]  `main` 브랜치의 최신 코드를 `pull` 받았나요?
