### PR TITLE
[feat] 액세스 토큰 갱신 로직 수정

### DIFF
--- a/src/main/java/com/example/mogakserver/auth/api/request/TokenRequestDTO.java
+++ b/src/main/java/com/example/mogakserver/auth/api/request/TokenRequestDTO.java
@@ -1,4 +1,0 @@
-package com.example.mogakserver.auth.api.request;
-
-public record TokenRequestDTO(String accessToken, String refreshToken) {
-}

--- a/src/main/java/com/example/mogakserver/auth/application/response/LoginResponseDto.java
+++ b/src/main/java/com/example/mogakserver/auth/application/response/LoginResponseDto.java
@@ -11,22 +11,21 @@ public record LoginResponseDto(
         @JsonProperty("status")
         String status,
 
-        String accessToken,
-        String refreshToken
+        String accessToken
 ) {
 
     // 신규 사용자 로그인
     public static LoginResponseDto NewUserResponse(Long kakaoId) {
-        return new LoginResponseDto(kakaoId, "fail", null, null);
+        return new LoginResponseDto(kakaoId, "fail", null);
     }
 
     // 기존 사용자 로그인
-    public static LoginResponseDto ExistingUserResponse(String accessToken, String refreshToken) {
-        return new LoginResponseDto(null, "success", accessToken, refreshToken);
+    public static LoginResponseDto ExistingUserResponse(String accessToken) {
+        return new LoginResponseDto(null, "success", accessToken);
     }
 
     // 회원가입
-    public static LoginResponseDto SignupResponse(String accessToken, String refreshToken) {
-        return new LoginResponseDto(null, null, accessToken, refreshToken);
+    public static LoginResponseDto SignupResponse(String accessToken) {
+        return new LoginResponseDto(null, null, accessToken);
     }
 }

--- a/src/main/java/com/example/mogakserver/common/exception/dto/TokenPair.java
+++ b/src/main/java/com/example/mogakserver/common/exception/dto/TokenPair.java
@@ -1,7 +1,13 @@
 package com.example.mogakserver.common.exception.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record TokenPair(
         String accessToken, String refreshToken
 ) {
+    public static TokenPair accessTokenResponse(String accessToken) {
+        return new TokenPair(accessToken, null);
+    }
 }
 

--- a/src/main/java/com/example/mogakserver/common/exception/enums/ErrorCode.java
+++ b/src/main/java/com/example/mogakserver/common/exception/enums/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     EMPTY_KAKAO_ID_EXCEPTION(HttpStatus.UNAUTHORIZED, "카카오 ID 값을 입력해 주세요."),
     TOKEN_NOT_CONTAINED_EXCEPTION(HttpStatus.UNAUTHORIZED, "Access Token이 필요합니다."),
     TOKEN_TIME_EXPIRED_EXCEPTION(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    REFRESH_TOKEN_TIME_EXPIRED_EXCEPTION(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),
 
     //403
     ROOM_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "방 관련 권한이 없습니다."),


### PR DESCRIPTION
## 🍀 연관된 이슈
- resolved #32 

## 💻 작업 내용
로그인할 때 쿠키에 리프레시 토큰을 저장하고 3일 이내 만료나 이미 만료시에는 다시 갱신되도록 수정했습니다.
/refresh 요청하면 쿠키에 있는 리프레시 토큰을 통해 액세스 토큰 갱신될 수 있도록 수정했습니다!

## 👥 리뷰 요청 및 전달 사항

- [x]  `main` 브랜치의 최신 코드를 `pull` 받았나요?
