### PR TITLE
[fix] 현재 참여 인원 웹소켓 세션 기반으로 수정

### DIFF
--- a/src/main/java/com/example/mogakserver/room/application/service/RoomRegisterService.java
+++ b/src/main/java/com/example/mogakserver/room/application/service/RoomRegisterService.java
@@ -97,8 +97,8 @@ public class RoomRegisterService {
 
     private boolean isUserHost(Long userId, Long roomId) {
         return roomUserRepository.findByUserIdAndRoomId(userId, roomId)
-                .map(RoomUser::isHost)
-                .orElse(false);
+            .stream()
+            .anyMatch(RoomUser::isHost);
     }
 
     private void validateHostPermission(Long userId, Long roomId) {

--- a/src/main/java/com/example/mogakserver/room/application/service/RoomRetrieveService.java
+++ b/src/main/java/com/example/mogakserver/room/application/service/RoomRetrieveService.java
@@ -215,8 +215,8 @@ public class RoomRetrieveService {
 
     private boolean isUserHost(Long userId, Long roomId) {
         return roomUserRepository.findByUserIdAndRoomId(userId, roomId)
-                .map(RoomUser::isHost)
-                .orElse(false);
+            .stream()
+            .anyMatch(RoomUser::isHost);
     }
 
     public void isRoomNameAvailable(String roomName) {

--- a/src/main/java/com/example/mogakserver/roomuser/application/service/RoomUserService.java
+++ b/src/main/java/com/example/mogakserver/roomuser/application/service/RoomUserService.java
@@ -37,6 +37,7 @@ import org.springframework.web.socket.WebSocketSession;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +64,15 @@ public class RoomUserService {
     private final WebRtcWebSocketHandler webRtcWebSocketHandler;
 
     public void updateIsScreenShareLargeAllowed(Long userId, Long roomId){
-        RoomUser roomUser = roomUserRepository.findByUserIdAndRoomId(userId, roomId).orElseThrow(()->new NotFoundException(ErrorCode.NOT_FOUND_ROOM_EXCEPTION));
+        List<RoomUser> roomUsers = roomUserRepository.findByUserIdAndRoomId(userId, roomId);
+
+        if (roomUsers.isEmpty()) {
+            throw new NotFoundException(ErrorCode.NOT_FOUND_ROOM_EXCEPTION);
+        }
+
+        RoomUser roomUser = roomUsers.stream()
+            .max(Comparator.comparing(RoomUser::getCreatedAt))
+            .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ROOM_EXCEPTION));
         roomUser.updateIsVideoLargeAllowed();
     }
     @Transactional(readOnly = true)
@@ -83,7 +92,15 @@ public class RoomUserService {
 
         boolean isScreenSharing = redisTemplate.opsForSet().isMember(screenShareKey, String.valueOf(userId));
 
-        RoomUser roomUser = roomUserRepository.findByUserIdAndRoomId(userId, roomId).orElseThrow(()->new NotFoundException(ErrorCode.NOT_FOUND_ROOM_EXCEPTION));
+        List<RoomUser> roomUsers = roomUserRepository.findByUserIdAndRoomId(userId, roomId);
+
+        if (roomUsers.isEmpty()) {
+            throw new NotFoundException(ErrorCode.NOT_FOUND_ROOM_EXCEPTION);
+        }
+
+        RoomUser roomUser = roomUsers
+            .stream().max(Comparator.comparing(RoomUser::getCreatedAt))
+            .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ROOM_EXCEPTION));
 
         return MyStatusResponseDTO.builder()
                 .nickName(nickName)
@@ -328,7 +345,9 @@ public class RoomUserService {
             roomUserRepository.save(roomUser);
             roomUserId = roomUser.getId();
         } else{
-            roomUserId = roomUserRepository.findByUserIdAndRoomId(userId, roomId).get().getId();
+            List<RoomUser> roomUsers = roomUserRepository.findByUserIdAndRoomId(userId, roomId);
+            RoomUser roomUser = roomUsers.get(0);
+            roomUserId = roomUser.getId();
         }
         return roomUserId;
     }

--- a/src/main/java/com/example/mogakserver/roomuser/application/service/RoomUserService.java
+++ b/src/main/java/com/example/mogakserver/roomuser/application/service/RoomUserService.java
@@ -154,7 +154,7 @@ public class RoomUserService {
 
 
     @NotNull
-    private static List<MyPageUserRoomDTO> getMyPageRoomDTOs(Page<Room> roomPage, Map<Long, Long> roomTotalTimeMap, Map<Long, String> roomImgMap, Map<Long, List<WorkHour>> workHourMap) {
+    private List<MyPageUserRoomDTO> getMyPageRoomDTOs(Page<Room> roomPage, Map<Long, Long> roomTotalTimeMap, Map<Long, String> roomImgMap, Map<Long, List<WorkHour>> workHourMap) {
         List<MyPageUserRoomDTO> roomDTOList = roomPage.stream()
                 .map(room -> {
                     long totalSeconds = roomTotalTimeMap.getOrDefault(room.getId(), 0L);
@@ -162,6 +162,7 @@ public class RoomUserService {
                     int min = (int) ((totalSeconds % 3600) / 60);
                     int sec = (int) (totalSeconds % 60);
 
+                    List<WebSocketSession> roomSessions = webRtcWebSocketHandler.getSessionsByRoomId(room.getId());
                     return new MyPageUserRoomDTO(
                             room.getId(),
                             room.getRoomName(),
@@ -169,7 +170,7 @@ public class RoomUserService {
                             room.getRoomExplain(),
                             workHourMap.getOrDefault(room.getId(), Collections.emptyList()),
                             room.isLocked(),
-                            room.getUserCnt(),
+                            roomSessions.size(),
                             room.getRoomPassword(),
                             hour, min, sec
                     );

--- a/src/main/java/com/example/mogakserver/roomuser/infra/repository/JpaRoomUserRepository.java
+++ b/src/main/java/com/example/mogakserver/roomuser/infra/repository/JpaRoomUserRepository.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface JpaRoomUserRepository extends JpaRepository<RoomUser, Long> {
-    Optional<RoomUser> findByUserIdAndRoomId(Long userId, Long roomId);
+    List<RoomUser> findByUserIdAndRoomId(Long userId, Long roomId);
     List<RoomUser> findByRoomId(Long roomId);
 
     void deleteByRoomId(Long roomId);


### PR DESCRIPTION
## 🍀 연관된 이슈
- resolved #61

## 💻 작업 내용
- 7일간 들어갔던 / 내가 만든 모각방 리스트 참여인원 수정
- findByRoomUser 이 multiple row 반환 가능 -> list 로 수정 기준은 가장 최신 roomUser 반환
## 👥 리뷰 요청 및 전달 사항


- [ ]  `main` 브랜치의 최신 코드를 `pull` 받았나요?
